### PR TITLE
Add a vignette effect

### DIFF
--- a/include/effects.h
+++ b/include/effects.h
@@ -9,12 +9,17 @@ struct swaylock_effect {
 			int radius, times;
 		} blur;
 		double scale;
+		struct {
+			double base;
+			double factor;
+		} vignette;
 	} e;
 
 	enum {
 		EFFECT_BLUR,
 		EFFECT_SCALE,
 		EFFECT_GREYSCALE,
+		EFFECT_VIGNETTE,
 	} tag;
 };
 

--- a/main.c
+++ b/main.c
@@ -664,6 +664,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		LO_EFFECT_BLUR,
 		LO_EFFECT_SCALE,
 		LO_EFFECT_GREYSCALE,
+		LO_EFFECT_VIGNETTE,
 		LO_INDICATOR,
 		LO_CLOCK,
 		LO_TIMESTR,
@@ -726,6 +727,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"effect-blur", required_argument, NULL, LO_EFFECT_BLUR},
 		{"effect-scale", required_argument, NULL, LO_EFFECT_SCALE},
 		{"effect-greyscale", no_argument, NULL, LO_EFFECT_GREYSCALE},
+		{"effect-vignette", required_argument, NULL, LO_EFFECT_VIGNETTE},
 		{"indicator", no_argument, NULL, LO_INDICATOR},
 		{"clock", no_argument, NULL, LO_CLOCK},
 		{"timestr", required_argument, NULL, LO_TIMESTR},
@@ -860,6 +862,8 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Scale images.\n"
 		"  --effect-greyscale               "
 			"Make images greyscale.\n"
+		"  --effect-vignette <base>:<factor>           "
+			"Apply a vignette effect to images. base and factor should be numbers between 0 and 1\n"
 		"\n"
 		"All <color> options are of the form <rrggbb[aa]>.\n";
 
@@ -1154,6 +1158,18 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 						sizeof(*state->args.effects) * ++state->args.effects_count);
 				struct swaylock_effect *effect = &state->args.effects[state->args.effects_count - 1];
 				effect->tag = EFFECT_GREYSCALE;
+			}
+			break;
+		case LO_EFFECT_VIGNETTE:
+			if (state) {
+				state->args.effects = realloc(state->args.effects,
+						sizeof(*state->args.effects) * ++state->args.effects_count);
+				struct swaylock_effect *effect = &state->args.effects[state->args.effects_count - 1];
+				effect->tag = EFFECT_VIGNETTE;
+				if (sscanf(optarg, "%lf:%lf", &effect->e.vignette.base, &effect->e.vignette.factor) != 2) {
+					swaylock_log(LOG_ERROR, "Invalid factor effect argument %s, ignoring", optarg);
+					state->args.effects_count -= 1;
+				}
 			}
 			break;
 		case LO_INDICATOR:


### PR DESCRIPTION
Adds a simple vignette effect (darkens the borders of the image).

There are two parameters, `base` and `factor`, both are in the range 0-1, `base` specifies how dark is the darkest part of the image and `factor` specifies how much brighter is the brightest part, so e.g. `0.2:0.6` will cause the borders to be 0.2 times darker than the original image, while the center will be 0.8 times darker. 

Not sure about the names of the parameters.

Can also be used as a simple darken effect if the factor is specified as 0.