### PR TITLE
Added option --submit-on-touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The main new features compared to upstream swaylock are:
 	* Use `--indicator` to make the indicator always active
 	* Use `--timestr` and `--datestr` to set the date/time formats
 	  (using strftime-style formatting)
+* `--submit-on-touch` to use your touchscreen to submit a password.
+  If you can unlock your device with anything else than your password,
+  this might come helpful to trigger PAM's authentication process.
 * `--grace <seconds>` to set a password grace period, so that the password
   isn't required to unlock until some number of seconds have passed.
 	* Used together with `--indicator`, the indicator is always shown,

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -75,6 +75,7 @@ struct swaylock_args {
 	char *timestr;
 	char *datestr;
 	uint32_t fade_in;
+	bool password_submit_on_touch;
 	uint32_t password_grace_period;
 	bool password_grace_no_mouse;
 	bool password_grace_no_touch;

--- a/main.c
+++ b/main.c
@@ -823,6 +823,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		LO_TIMESTR,
 		LO_DATESTR,
 		LO_FADE_IN,
+		LO_SUBMIT_ON_TOUCH,
 		LO_GRACE,
 		LO_GRACE_NO_MOUSE,
 		LO_GRACE_NO_TOUCH,
@@ -895,6 +896,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"timestr", required_argument, NULL, LO_TIMESTR},
 		{"datestr", required_argument, NULL, LO_DATESTR},
 		{"fade-in", required_argument, NULL, LO_FADE_IN},
+		{"submit-on-touch", no_argument, NULL, LO_SUBMIT_ON_TOUCH},
 		{"grace", required_argument, NULL, LO_GRACE},
 		{"grace-no-mouse", no_argument, NULL, LO_GRACE_NO_MOUSE},
 		{"grace-no-touch", no_argument, NULL, LO_GRACE_NO_TOUCH},
@@ -918,6 +920,8 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Detach from the controlling terminal after locking.\n"
 		"  --fade-in <seconds>              "
 			"Make the lock screen fade in instead of just popping in.\n"
+		"  --submit-on-touch                "
+			"Submit password in response to a touch event.\n"
 		"  --grace <seconds>                "
 			"Password grace period. Don't require the password for the first N seconds.\n"
 		"  --grace-no-mouse                 "
@@ -1425,6 +1429,11 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		case LO_FADE_IN:
 			if (state) {
 				state->args.fade_in = parse_seconds(optarg);
+			}
+			break;
+		case LO_SUBMIT_ON_TOUCH:
+			if (state) {
+				state->args.password_submit_on_touch = true;
 			}
 			break;
 		case LO_GRACE:

--- a/password.c
+++ b/password.c
@@ -101,6 +101,8 @@ void swaylock_handle_mouse(struct swaylock_state *state) {
 void swaylock_handle_touch(struct swaylock_state *state) {
 	if (state->auth_state == AUTH_STATE_GRACE && !state->args.password_grace_no_touch) {
 		state->run_display = false;
+	} else if (state->auth_state != AUTH_STATE_VALIDATING && state->args.password_submit_on_touch) {
+		submit_password(state);
 	}
 }
 

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -38,6 +38,9 @@ Locks your Wayland session.
 *--fade-in* <seconds>
 	Fade in the lock screen.
 
+*--submit-on-touch*
+	Submit password in response to a touch event.
+
 *--grace* <seconds>
 	Only require a password after some grace period.
 


### PR DESCRIPTION
Helpful with authentication methods of PAM not based on passwords, like:
- Biometric authentication methods (face, fingerprint, iris)
- Notification based unlock
- Unlock if phone is nearby and unlocked

I use this feature on my tablet together with [howdy](https://github.com/boltgolt/howdy),
but I think this can be useful to others as well,
for example if you think the return key is still to small.