### PR TITLE
Feature: GIF playback on input

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -69,7 +69,8 @@ struct swaylock_args {
 	struct swaylock_effect *effects;
 	int effects_count;
 	bool indicator;
-	bool clock;
+	bool gif;
+    bool clock;
 	char *timestr;
 	char *datestr;
 };
@@ -77,6 +78,15 @@ struct swaylock_args {
 struct swaylock_password {
 	size_t len;
 	char buffer[1024];
+};
+
+struct swaylock_gif {
+    GdkPixbufAnimation *pixbuf_animation;
+    GTimeVal *time;
+    GdkPixbufAnimationIter *iter;
+    int delay, height, width;
+    GdkPixbuf *pixbuf;
+	struct wl_list link;
 };
 
 struct swaylock_state {
@@ -92,6 +102,7 @@ struct swaylock_state {
 	struct wl_shm *shm;
 	struct wl_list surfaces;
 	struct wl_list images;
+    struct swaylock_gif gif; 
 	struct swaylock_args args;
 	struct swaylock_password password;
 	struct swaylock_xkb xkb;

--- a/main.c
+++ b/main.c
@@ -632,6 +632,41 @@ static char *join_args(char **argv, int argc) {
 	return res;
 }
 
+static bool file_exists(const char *path) {
+	return path && access(path, R_OK) != -1;
+}
+
+static void load_gif(char *arg, struct swaylock_state *state){
+
+    state->gif.pixbuf_animation = gdk_pixbuf_animation_new_from_file (arg, NULL);
+    if (state->gif.pixbuf_animation != NULL){
+        state->args.gif = true;
+        swaylock_log(LOG_DEBUG, "Loading gif at %s", arg);
+
+        // fake start time to manipulate gif playback, every keystroke
+        // the time gets increased by duration of one gif frame
+       
+        struct _GTimeVal *fakeTime = calloc(1, sizeof(struct _GTimeVal));
+        fakeTime->tv_sec = 0;
+        fakeTime->tv_usec = 0;
+
+        state->gif.time = fakeTime;
+
+        state->gif.iter = gdk_pixbuf_animation_get_iter (state->gif.pixbuf_animation, state->gif.time);
+        
+
+        state->gif.delay = gdk_pixbuf_animation_iter_get_delay_time(state->gif.iter) * 1000;
+        
+        state->gif.pixbuf = gdk_pixbuf_animation_iter_get_pixbuf(state->gif.iter);
+
+        state->gif.height = gdk_pixbuf_get_height(state->gif.pixbuf);
+        state->gif.width = gdk_pixbuf_get_width(state->gif.pixbuf);
+        
+    } else {
+        fprintf(stderr, "ERROR: Animation could not be opened / no loader for the file format exists / not enough memory to allocate image buffer / image contains invalid data\n");
+    }
+}
+
 static void load_image(char *arg, struct swaylock_state *state) {
 	// [[<output>]:]<path>
 	struct swaylock_image *image = calloc(1, sizeof(struct swaylock_image));
@@ -783,6 +818,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		LO_EFFECT_COMPOSE,
 		LO_EFFECT_CUSTOM,
 		LO_INDICATOR,
+        LO_GIF,
 		LO_CLOCK,
 		LO_TIMESTR,
 		LO_DATESTR,
@@ -850,6 +886,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"effect-compose", required_argument, NULL, LO_EFFECT_COMPOSE},
 		{"effect-custom", required_argument, NULL, LO_EFFECT_CUSTOM},
 		{"indicator", no_argument, NULL, LO_INDICATOR},
+        {"gif", required_argument, NULL, LO_GIF},
 		{"clock", no_argument, NULL, LO_CLOCK},
 		{"timestr", required_argument, NULL, LO_TIMESTR},
 		{"datestr", required_argument, NULL, LO_DATESTR},
@@ -899,6 +936,8 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"The format string for the time. Defaults to '%T'.\n"
 		"  --datestr <format>               "
 			"The format string for the date. Defaults to '%a, %x'.\n"
+        "  --gif <path>                     "
+            "Sets the gif to show, which advances by 1 frame every keystroke.\n"
 		"  -v, --version                    "
 			"Show the version number and quit.\n"
 		"  --bs-hl-color <color>            "
@@ -1341,6 +1380,13 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 				state->args.indicator = true;
 			}
 			break;
+        case LO_GIF:
+            if (state)  {
+                load_gif(optarg, state);
+                //centers the gif on screen (if no indicator offset was set)
+                state->args.radius = state->gif.width/2; //pretty hacky, is obsolete if the gif is placed onto its own surface,
+            }
+            break;
 		case LO_CLOCK:
 			if (state) {
 				state->args.clock = true;
@@ -1365,10 +1411,6 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 	}
 
 	return 0;
-}
-
-static bool file_exists(const char *path) {
-	return path && access(path, R_OK) != -1;
 }
 
 static char *get_config_path(void) {
@@ -1500,6 +1542,7 @@ int main(int argc, char **argv) {
 		.effects = NULL,
 		.effects_count = 0,
 		.indicator = false,
+        .gif = false,
 		.clock = false,
 		.timestr = strdup("%T"),
 		.datestr = strdup("%a, %x"),
@@ -1605,7 +1648,7 @@ int main(int argc, char **argv) {
 		}
 
 		if (!done) {
-			fprintf(stderr, "failed to screenshoot all outputs\n");
+			fprintf(stderr, "Failed to screenshot all outputs\n");
 			return EXIT_FAILURE;
 		}
 	}

--- a/meson.build
+++ b/meson.build
@@ -6,19 +6,18 @@ project(
 	meson_version: '>=0.48.0',
 	default_options: [
 		'c_std=c11',
-		'warning_level=2',
-		'werror=true',
+        'warning_level=1',
 	],
 )
 
 add_project_arguments(
 	[
-		'-Wno-unused-parameter',
-		'-Wno-unused-result',
-		'-Wundef',
-		'-Wvla',
-		'-fopenmp',
-		'-O3',
+      '-Wno-unused-parameter',
+      '-Wno-unused-result',
+      '-Wno-deprecated-declarations',
+      '-Wundef',
+	  '-fopenmp',
+	  '-O3',
 	],
 	language: 'c',
 )
@@ -56,6 +55,7 @@ crypt          = cc.find_library('crypt', required: not libpam.found())
 math           = cc.find_library('m')
 rt             = cc.find_library('rt')
 dl             = cc.find_library('dl')
+gtk            = dependency('gtk+-2.0')
 
 git = find_program('git', required: false)
 scdoc = find_program('scdoc', required: get_option('man-pages'))
@@ -133,6 +133,7 @@ dependencies = [
 	dl,
 	xkbcommon,
 	wayland_client,
+    gtk
 ]
 
 sources = [


### PR DESCRIPTION
I added a `--gif <path>` option, which allows for any GIF to be chosen and displayed on the lock screen, where the frames advance only while typing. For regular password input, the GIF advances by one frame per keystroke, backspace reverses one frame, and clearing (Ctrl+C), password rejection (wrong password) aswell as idling resets the GIF to the first frame.

All GIF related variables are stored in the form of `struct swaylock_gif` from `include/swaylock.h` in `swaylock_state`.

The GIF itself is loaded by gdk as an pixbuf animation in `main.c`, via the function 
`static void load_gif(char *arg, struct swaylock_state *state)` (line 717)
where the arg is the path given in the CLI option.

To advance the GIF by one frame per Keystroke (and currently also once a second when the clock is updated, although this behaviour is not intended), an iterator (state->gif.iter) provided by gdk pixbuf is tricked. The iterator chooses the frame to display based on a timestamp in this function:  `gdk_pixbuf_animation_iter_advance(state->gif.iter, state->gif.time);`, where gif.time is a struct called `GTimeVal` which contains seconds and microseconds. The timestamp is updated upon every call to `void render_frame(struct swaylock_surface *surface)` in `render.c`. The first frame is always shown when the seconds and microseconds in gif.time are set to 0. When the frame should switch to the next frame, the GIF specific delay (found in state->gif.delay) is added to or substracted from the current microseconds.
Thereafter, the new frame is returned as a pixbuf and painted to the current surface using `gdk_cairo_set_source_pixbuf(cairo, state->gif.pixbuf, 0, 0);` und applied via `cairo_paint(cairo);`.

Currently, the GIF is painted to the same surface the indicator is on, as i did not entirely catch on to the window/surface handling in the project, and only unsuccesfully fumbled around with it (the `struct wl_list link` in `state->gif` is a remnant of this), aswell as https://github.com/mortie/swaylock-effects/issues/17#issuecomment-628587297.

Since the GIF does not feature its own surface, the indicator radius is set to double its width in line 1498 of `main.c`. This is necessary to fit the whole gif onto the indicator surface, as they will get clipped and not shown entirely if the radius and thus the surface is too small. This is rather ugly and only works properly (centers) square GIFs. 

This feature adds gtk as a dependency to the project.

Anyways, i like the result, especially with [this](https://media.giphy.com/media/UqwLwFj26GSyR968z6/giphy.gif) GIF (works well with the clock inside and a long password). For the clock and the datestring to be properly formatted, and the indicator invisible, i use the following swaylock command:
`./swaylock --gif ~/Pictures/lockgif.gif --inside-color 00000000 --ring-color 00000000 --line-color 00000000 --indicator-thickness 0 -e --font-size 26 --text-color AAAAAAAA --inside-ver-color 00000000 --inside-clear-color 00000000 --inside-wrong-color FF000044`
and changed two options of text handling in `render.c`, on line 362 and 368 to have the datestring follow the --font-size option and have its y-offset be independent from the indicator radius.

I do invite you to give it a try (maybe with the suggested GIF and command), and would like to hear your opinion.