### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/effects.c
+++ b/effects.c
@@ -1,5 +1,5 @@
 #define _POSIX_C_SOURCE 200809
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <omp.h>
 #include <limits.h>
 #include <stdlib.h>


### PR DESCRIPTION
On FreeBSD `_XOPEN_SOURCE` overrides `_POSIX_C_SOURCE`. `fmin` (C99) and `CLOCK_MONOTONIC` require `_XOPEN_SOURCE >= 600`.

https://github.com/freebsd/freebsd/blob/releng/12.2/sys/sys/cdefs.h#L690-L693
https://github.com/freebsd/freebsd/blob/releng/12.2/lib/msun/src/math.h#L312
https://github.com/freebsd/freebsd/blob/releng/12.2/include/time.h#L108
