### PR TITLE
Add -D/--dpms option to power off displays when idle

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -10,6 +10,7 @@
 #include "effects.h"
 #include "fade.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
+#include "wlr-output-power-management-unstable-v1-client-protocol.h"
 
 enum auth_state {
 	AUTH_STATE_IDLE,
@@ -80,6 +81,7 @@ struct swaylock_args {
 	uint32_t password_grace_period;
 	bool password_grace_no_mouse;
 	bool password_grace_no_touch;
+	bool use_dpms;
 };
 
 struct swaylock_password {
@@ -110,6 +112,7 @@ struct swaylock_state {
 	size_t n_screenshots_done;
 	bool run_display;
 	struct zxdg_output_manager_v1 *zxdg_output_manager;
+	struct zwlr_output_power_manager_v1 *zwlr_output_power_manager;
 };
 
 struct swaylock_surface {
@@ -142,6 +145,9 @@ struct swaylock_surface {
 	enum wl_output_transform transform;
 	char *output_name;
 	struct wl_list link;
+	struct zwlr_output_power_v1 *wlr_output_power;
+	enum zwlr_output_power_v1_mode power_mode;
+	bool power_mode_pending;
 };
 
 // There is exactly one swaylock_image for each -i argument

--- a/main.c
+++ b/main.c
@@ -27,6 +27,7 @@
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "wlr-screencopy-unstable-v1-client-protocol.h"
 #include "xdg-output-unstable-v1-client-protocol.h"
+#include "wlr-output-power-management-unstable-v1-client-protocol.h"
 
 // returns a positive integer in milliseconds
 static uint32_t parse_seconds(const char *seconds) {
@@ -401,6 +402,26 @@ static const struct wl_callback_listener surface_frame_listener = {
 	.done = surface_frame_handle_done,
 };
 
+void set_dpms(struct swaylock_state *state) {
+	if (!state->args.use_dpms) {
+		return;
+	}
+
+	enum zwlr_output_power_v1_mode intended_mode = state->auth_state == AUTH_STATE_IDLE ?
+		ZWLR_OUTPUT_POWER_V1_MODE_OFF : ZWLR_OUTPUT_POWER_V1_MODE_ON;
+
+	struct swaylock_surface *surface;
+	wl_list_for_each(surface, &state->surfaces, link) {
+		if (!surface->wlr_output_power || surface->power_mode_pending ||
+				surface->power_mode == intended_mode) {
+			continue;
+		}
+
+		zwlr_output_power_v1_set_mode(surface->wlr_output_power, intended_mode);
+		surface->power_mode_pending = true;
+	}
+}
+
 void damage_surface(struct swaylock_surface *surface) {
 	surface->dirty = true;
 	if (surface->frame_pending) {
@@ -418,6 +439,8 @@ void damage_state(struct swaylock_state *state) {
 	wl_list_for_each(surface, &state->surfaces, link) {
 		damage_surface(surface);
 	}
+
+	set_dpms(state);
 }
 
 static void handle_wl_output_geometry(void *data, struct wl_output *wl_output,
@@ -701,6 +724,28 @@ struct zxdg_output_v1_listener _xdg_output_listener = {
 	.description = handle_xdg_output_description,
 };
 
+static void handle_wlr_output_power_mode(void *data,
+		struct zwlr_output_power_v1 *output_power, uint32_t mode) {
+	struct swaylock_surface *surface = data;
+	assert(surface->wlr_output_power == output_power);
+	surface->power_mode = mode;
+	surface->power_mode_pending = false;
+}
+
+static void handle_wlr_output_power_failed(void *data,
+		struct zwlr_output_power_v1 *output_power) {
+	struct swaylock_surface *surface = data;
+	swaylock_log(LOG_ERROR, "wlr_output_power_set_mode failed");
+	assert(surface->wlr_output_power == output_power);
+	surface->wlr_output_power = NULL;
+	zwlr_output_power_v1_destroy(output_power);
+}
+
+struct zwlr_output_power_v1_listener _wlr_output_power_listener = {
+	.mode = handle_wlr_output_power_mode,
+	.failed = handle_wlr_output_power_failed,
+};
+
 static void handle_global(void *data, struct wl_registry *registry,
 		uint32_t name, const char *interface, uint32_t version) {
 
@@ -730,6 +775,9 @@ static void handle_global(void *data, struct wl_registry *registry,
 	} else if (strcmp(interface, zxdg_output_manager_v1_interface.name) == 0) {
 		state->zxdg_output_manager = wl_registry_bind(
 				registry, name, &zxdg_output_manager_v1_interface, 2);
+	} else if (strcmp(interface, zwlr_output_power_manager_v1_interface.name) == 0) {
+		state->zwlr_output_power_manager = wl_registry_bind(
+				registry, name, &zwlr_output_power_manager_v1_interface, 1);
 	} else if (strcmp(interface, wl_output_interface.name) == 0) {
 		struct swaylock_surface *surface =
 			calloc(1, sizeof(struct swaylock_surface));
@@ -967,6 +1015,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"config", required_argument, NULL, 'C'},
 		{"color", required_argument, NULL, 'c'},
 		{"debug", no_argument, NULL, 'd'},
+		{"dpms", no_argument, NULL, 'D'},
 		{"trace", no_argument, NULL, LO_TRACE},
 		{"ignore-empty-password", no_argument, NULL, 'e'},
 		{"daemonize", no_argument, NULL, 'f'},
@@ -1048,6 +1097,8 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Turn the screen into the given color instead of white.\n"
 		"  -d, --debug                      "
 			"Enable debugging output.\n"
+		"  -D, --dpms                       "
+			"Power off displays using DPMS when lockscreen is idle.\n"
 		"  -t, --trace                      "
 			"Enable tracing output.\n"
 		"  -e, --ignore-empty-password      "
@@ -1199,7 +1250,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 	optind = 1;
 	while (1) {
 		int opt_idx = 0;
-		c = getopt_long(argc, argv, "c:deFfhi:SkKLlnrs:tuvC:", long_options,
+		c = getopt_long(argc, argv, "c:dDeFfhi:SkKLlnrs:tuvC:", long_options,
 				&opt_idx);
 		if (c == -1) {
 			break;
@@ -1217,6 +1268,11 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			break;
 		case 'd':
 			swaylock_log_init(LOG_DEBUG);
+			break;
+		case 'D':
+			if (state) {
+				state->args.use_dpms = true;
+			}
 			break;
 		case LO_TRACE:
 			swaylock_log_init(LOG_TRACE);
@@ -1752,6 +1808,7 @@ int main(int argc, char **argv) {
 		.timestr = strdup("%T"),
 		.datestr = strdup("%a, %x"),
 		.password_grace_period = 0,
+		.use_dpms = false
 	};
 	wl_list_init(&state.images);
 	set_default_colors(&state.args.colors);
@@ -1847,10 +1904,26 @@ int main(int argc, char **argv) {
 				iter_image->cairo_surface, &state, 1);
 	}
 
+	if (state.zwlr_output_power_manager) {
+		struct swaylock_surface *surface;
+		wl_list_for_each(surface, &state.surfaces, link) {
+			surface->wlr_output_power = zwlr_output_power_manager_v1_get_output_power(
+					state.zwlr_output_power_manager, surface->output);
+			zwlr_output_power_v1_add_listener(
+					surface->wlr_output_power, &_wlr_output_power_listener, surface);
+		}
+		wl_display_roundtrip(state.display);
+	} else {
+		swaylock_log(LOG_INFO, "Compositor does not support zwlr_output_power_"
+				"manager, DPMS will not work");
+	}
+
 	struct swaylock_surface *surface;
 	wl_list_for_each(surface, &state.surfaces, link) {
 		create_layer_surface(surface);
 	}
+
+	set_dpms(&state);
 
 	wl_list_for_each(surface, &state.surfaces, link) {
 		while (surface->events_pending > 0) {
@@ -1887,6 +1960,10 @@ int main(int argc, char **argv) {
 		}
 		loop_poll(state.eventloop);
 	}
+
+	// auth_state is now AUTH_STATE_VALIDATING, meaning this call will
+	// ensure the display(s) are on.
+	set_dpms(&state);
 
 	if (state.args.daemonize && state.args.fade_in) {
 		daemonize_done(&daemonfd); // In case we exit before --fade-in timeout

--- a/meson.build
+++ b/meson.build
@@ -108,6 +108,7 @@ client_protocols = [
 	['wlr-layer-shell-unstable-v1.xml'],
 	['wlr-input-inhibitor-unstable-v1.xml'],
 	['wlr-screencopy-unstable-v1.xml'],
+	['wlr-output-power-management-unstable-v1.xml'],
 ]
 
 foreach p : client_protocols

--- a/wlr-output-power-management-unstable-v1.xml
+++ b/wlr-output-power-management-unstable-v1.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_output_power_management_unstable_v1">
+  <copyright>
+    Copyright © 2019 Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Control power management modes of outputs">
+    This protocol allows clients to control power management modes
+    of outputs that are currently part of the compositor space. The
+    intent is to allow special clients like desktop shells to power
+    down outputs when the system is idle.
+
+    To modify outputs not currently part of the compositor space see
+    wlr-output-management.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_output_power_manager_v1" version="1">
+    <description summary="manager to create per-output power management">
+      This interface is a manager that allows creating per-output power
+      management mode controls.
+    </description>
+
+    <request name="get_output_power">
+      <description summary="get a power management for an output">
+        Create an output power management mode control that can be used to
+        adjust the power management mode for a given output.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_power_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_power_v1" version="1">
+    <description summary="adjust power management mode for an output">
+      This object offers requests to set the power management mode of
+      an output.
+    </description>
+
+    <enum name="mode">
+      <entry name="off" value="0"
+             summary="Output is turned off."/>
+      <entry name="on" value="1"
+             summary="Output is turned on, no power saving"/>
+    </enum>
+
+    <enum name="error">
+      <entry name="invalid_mode" value="1" summary="nonexistent power save mode"/>
+    </enum>
+
+    <request name="set_mode">
+      <description summary="Set an outputs power save mode">
+        Set an output's power save mode to the given mode. The mode change
+        is effective immediately. If the output does not support the given
+        mode a failed event is sent.
+      </description>
+      <arg name="mode" type="uint" enum="mode" summary="the power save mode to set"/>
+    </request>
+
+    <event name="mode">
+      <description summary="Report a power management mode change">
+        Report the power management mode change of an output.
+
+        The mode event is sent after an output changed its power
+        management mode. The reason can be a client using set_mode or the
+        compositor deciding to change an output's mode.
+        This event is also sent immediately when the object is created
+        so the client is informed about the current power management mode.
+      </description>
+      <arg name="mode" type="uint" enum="mode"
+           summary="the output's new power management mode"/>
+    </event>
+
+    <event name="failed">
+      <description summary="object no longer valid">
+        This event indicates that the output power management mode control
+        is no longer valid. This can happen for a number of reasons,
+        including:
+        - The output doesn't support power management
+        - Another client already has exclusive power management mode control
+          for this output
+        - The output disappeared
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this power management">
+        Destroys the output power management mode control object.
+      </description>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
(Originally submitted upstream as swaywm/swaylock#152, but rejected as out-of-scope.)

This option makes use of the new wlr-output-power-management protocol to power off displays when swaylock is idle (i.e. when the unlock indicator, if enabled, is not shown).

This approach provides far more reliable DPMS control than the currently recommended solution, which is to use something above swaylock (e.g. swayidle) to coordinate swaylock invocation with a separate swaymsg invocation to control DPMS. Since swayidle is purely input-based and cannot inspect swaylock's state, it will inevitably either power up the screens when it shouldn't or fail to when it should. For example, if swayidle is set to turn on the screens on "resume," it will do so even if the only input was a mouse bump, modifier key press, or something else that swaylock ignores completely.

This is a first pass at the functionality. I've been using it on my laptop with Sway for several months and it seem to work well. However, I occasionally do get in a state where the screen is stuck off after resuming, which I assume means the power manager interface has gone away. I have not yet tracked down why this happens.