### PR TITLE
Add T2 SDE package

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ implement them), new feature implementations are welcome as pull requests :)
   (thanks to Edd Salkield)
 * FreeBSD: [swaylock-effects](https://www.freshports.org/x11/swaylock-effects/)
 * Gentoo (GURU overlay): [swaylock-effects](https://gpo.zugaina.org/Overlays/guru/gui-apps/swaylock-effects)
+* T2 SDE: [swaylock-effects](https://t2sde.org/packages/swaylock-effects)
 
 ### Compiling from Source
 


### PR DESCRIPTION
Add T2 SDE to the "Installation" "From Package" list.

(T2 added the `swaylock-effects` package on [10 Apr 2021](https://svn.exactcode.de/ChangeLog-t2).)