### PR TITLE
fix: add missing include for stdlib.h

### DIFF
--- a/fade.c
+++ b/fade.c
@@ -1,6 +1,7 @@
 #include "fade.h"
 #include "pool-buffer.h"
 #include "swaylock.h"
+#include <stdlib.h>
 #include <stdio.h>
 #include <omp.h>
 #include <stdalign.h>


### PR DESCRIPTION
fixes compilation on Alpine Linux x86/armhf/armv7

error: implicit declaration of function 'malloc' -Werror=implicit-function-declaration
   83 |  fade->original_buffer = malloc(size);
      |                          ^~~~~~[
../fade.c:83:26: error: incompatible implicit declaration of built-in function 'malloc' -Werror
../fade.c:8:1: note: include '<stdlib.h>' or provide a declaration of 'malloc'
    7 | #include <string.h>
  +++ | #include <stdlib.h>
    8 |