### PR TITLE
Correctly handle multiple configure on wlr_layer_surface

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -134,6 +134,7 @@ struct swaylock_surface {
 	struct pool_buffer *current_buffer;
 	struct swaylock_fade fade;
 	int events_pending;
+	bool configured;
 	bool frame_pending, dirty;
 	uint32_t width, height;
 	uint32_t indicator_width, indicator_height;

--- a/main.c
+++ b/main.c
@@ -355,9 +355,10 @@ static void layer_surface_configure(void *data,
 	surface->indicator_height = 1;
 	zwlr_layer_surface_v1_ack_configure(layer_surface, serial);
 
-	if (--surface->events_pending == 0) {
+	if (!surface->configured && --surface->events_pending == 0) {
 		initially_render_surface(surface);
 	}
+	surface->configured = true;
 }
 
 static void layer_surface_closed(void *data,


### PR DESCRIPTION
This prevents us from rendering before the screenshot is ready, which
fixes #73.